### PR TITLE
Upgrade `oxc_sourcemap` to 0.31.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ description = "manipulate string like a wizard"
 [dependencies]
 index_vec = { version = "0.1.3" }
 rustc-hash = { version = "1.1.0" }
-oxc_sourcemap = { version = "0.25.0", optional = true}
+oxc_sourcemap = { version = "0.31.0", optional = true}
 
 [features]
 # Enable source map functionality


### PR DESCRIPTION
### Description

This PR upgrades `oxc_sourcemap` to 0.31.0 so it matches the version used within [rolldown](https://github.com/rolldown/rolldown) and unblocks this crate's `source_map` feature from being used there. The change has been tested using `cargo test --all-features` and building with `cargo build --all-features` works fine as well.