### PR TITLE
chore: upgrade version of oxc sourcemap to make compatible for usage in rolldown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ description = "manipulate string like a wizard"
 [dependencies]
 index_vec = { version = "0.1.3" }
 rustc-hash = { version = "1.1.0" }
-oxc_sourcemap = { version = "0.25.0", optional = true}
+oxc_sourcemap = { version = "0.31.0", optional = true}
 
 [features]
 # Enable source map functionality


### PR DESCRIPTION
While working on implementing source map support for the Replace plugin in rolldown, i am getting an error that says that two versions of oxc_sourcemap are installed

Updating the version of oxc_sourcemap here should fix the issue

Result of
```bash
cargo test --features source_map
```

<img width="721" alt="image" src="https://github.com/user-attachments/assets/7dcfaa66-af48-4e76-b681-98928447f3de">
<img width="851" alt="image" src="https://github.com/user-attachments/assets/e29e571c-500b-48ea-9099-b1127ce101fb">
